### PR TITLE
Add admin page for editing tiles and map.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,34 +4,25 @@ import Map from './components/Map';
 import * as db from './firebase';
 import { UserData } from "./providers/UserData";
 import schooner from "./assets/ships/two-masted-schooner.jpg";
+import { State } from './providers/GameState';
 
 interface AppProps {
   userData: UserData;
 }
 
 interface AppState {
-  map: db.MapRepr;
-  tiles: db.TileDict;
 }
 
-class App extends React.Component<AppProps, AppState> {
-  constructor(props: AppProps) {
+class App extends React.Component<State, AppState> {
+  constructor(props: State) {
     super(props);
-    this.state = {
-      map: [[]],
-      tiles: {}
-    };
+    this.state = {};
   }
 
-  async componentDidMount() {
-    const user: UserData = this.props.userData;
-    const map = await db.GetGridForGame(user.game_id);
-    const tiles = await db.GetTiles();
-    this.setState({map, tiles});
-  }
+  onTileClicked(row: number, col: number) {}
 
   render() {
-    const user = this.props.userData;
+    const user = this.props.user;
     return (
       <div className="app">
         <header className="header">
@@ -40,7 +31,7 @@ class App extends React.Component<AppProps, AppState> {
           <button onClick={db.SignOut}> Log Out </button>
         </header>
         <div className="content">
-          <Map map={this.state.map} tiles={this.state.tiles}/>
+          <Map map={this.props.map} tiles={this.props.tiles} onClick={this.onTileClicked}/>
           <div className="sidebar">
             <div className="turn-info">
               <p>Turn Number: 1</p>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {FunctionComponent} from 'react';
 import {
   BrowserRouter,
   Route,
@@ -54,7 +54,7 @@ export class Router extends React.Component<{}, RouterState> {
     return (
       <BrowserRouter>
         <Switch>
-          <Route path='/admin'><Admin {...resolvedState} /></Route>
+          <AdminRoute user={this.state.user} path='/admin'><Admin {...resolvedState} /></AdminRoute>
           <Route path='/game'><App {...resolvedState} /></Route>
           <Route path='/'>{this.redirectOnLogin()}</Route>
         </Switch>
@@ -62,5 +62,30 @@ export class Router extends React.Component<{}, RouterState> {
     );
   }
 }
+
+type AuthRouteProps = {
+  user: UserData;
+  path: string;
+}
+
+const AdminRoute: FunctionComponent<AuthRouteProps> = ({children, user, path}) => {
+  return (
+    <Route
+      path={path}
+      render={({ location }) =>
+        user.db_user.admin ? (
+          children
+        ) : (
+          <Redirect
+            to={{
+              pathname: '/game',
+              state: { from: location }
+            }}
+          />
+        )
+      }
+    />
+  );
+};
 
 export default Router;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,38 +1,63 @@
 import React from 'react';
 import {
   BrowserRouter,
-  Route
+  Route,
+  Switch,
+  Redirect,
 } from "react-router-dom";
 import App from './App';
 import Login from './components/login';
+import Admin from './components/admin';
+import { State } from './providers/GameState';
 import { UserData } from './providers/UserData';
-import { auth, GetShipAndGameForUser, ShipAndGame } from "./firebase";
+import * as db from "./firebase";
 
-export class Router extends React.Component<{}, {user: null | UserData}> {
+export interface RouterState {
+  user: null | UserData;
+  map: db.MapRepr;
+  tiles: db.TileDict;
+}
+
+export class Router extends React.Component<{}, RouterState> {
   constructor(props: {}) {
     super(props);
-    this.state = {user: null};
+    this.state = {user: null, map: [], tiles: {}};
   }
 
   componentDidMount = () => {
-    auth.onAuthStateChanged(async (userAuth) => {
+    db.auth.onAuthStateChanged(async (userAuth) => {
       if (!userAuth) {
         this.setState({ user: null });
         return;
       }
-      const ship_and_game: ShipAndGame = await GetShipAndGameForUser(userAuth);
-      const user_data = {user: userAuth, ...ship_and_game};
-      this.setState({ user: user_data });
+      const user = await db.GetUserData(userAuth);
+      const map = await db.GetGridForGame(user.game_id);
+      const tiles = await db.GetTiles();
+
+      this.setState({ user, map, tiles });
     });
   };
 
+  redirectOnLogin() {
+    if (this.state.user && this.state.user.db_user.admin) {
+      return (<Redirect to='/admin' />);
+    } else {
+      return (<Redirect to='/game' />);
+    }
+  }
   render() {
     if (!this.state.user) {
       return (<Login></Login>);
     }
+    // Reassign from RouterState to State to convert user from <User | null> to <User>
+    const resolvedState: State = {user: this.state.user, map: this.state.map, tiles: this.state.tiles};
     return (
       <BrowserRouter>
-        <Route path="/"><App userData={this.state.user} /></Route>
+        <Switch>
+          <Route path='/admin'><Admin {...resolvedState} /></Route>
+          <Route path='/game'><App {...resolvedState} /></Route>
+          <Route path='/'>{this.redirectOnLogin()}</Route>
+        </Switch>
       </BrowserRouter>
     );
   }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -3,14 +3,15 @@ import Tile from './Tile';
 import { MapRepr, TileDict } from '../firebase';
 import '../styles/Map.css';
 
-export function Map(props: {map: MapRepr, tiles: TileDict}) {
+export function Map(props: {map: MapRepr, tiles: TileDict, selectedRow?: number, selectedCol?: number, onClick: (row: number, col: number) => void}) {
   function renderTiles() {
     const map = [];
 
     for (let r = 0; r < props.map.length; r++) {
       const tiles = [];
       for (let c = 0; c < props.map[r].length; c++) {
-        tiles.push(<Tile key={r+','+c} tileInfo={props.tiles[props.map[r][c]]} />);
+        const selected = (r === props.selectedRow && c === props.selectedCol);
+        tiles.push(<Tile key={r+','+c} tileInfo={props.tiles[props.map[r][c]]} selected={selected} onClick={() => props.onClick(r, c)} />);
       }
       map.push(<tr key={r}>{tiles}</tr>);
     }

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { TileInfo } from '../firebase';
 
-export function Tile(props: {tileInfo: TileInfo}) {
+export function Tile(props: {tileInfo: TileInfo, selected: boolean, onClick: () => void}) {
   return (
-    <td className="tile" style={{backgroundColor: props.tileInfo.bg_color}}>
+    <td className={props.selected ? "tile selected" : "tile"} onClick={props.onClick} style={{backgroundColor: props.tileInfo.bg_color}}>
       <div className="hover"> {props.tileInfo.hover_text} </div>
     </td>
   );

--- a/src/components/TileEditor.tsx
+++ b/src/components/TileEditor.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { TileInfo } from '../firebase';
+
+export function TileEditor(props: {tileInfo: TileInfo, tileName: string}) {
+  return (
+    <div>
+      <h2>Tile: {props.tileName}</h2>
+      <h3>Hover Text: {props.tileInfo.hover_text}</h3>
+      <h3>Description: {props.tileInfo.description_text}</h3>
+    </div>
+  );
+}
+
+export default TileEditor;

--- a/src/components/admin.tsx
+++ b/src/components/admin.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as db from '../firebase';
 import { State } from '../providers/GameState';
-import { Redirect } from "react-router-dom";
 import { Map } from './Map';
 import { TileEditor } from './TileEditor';
 
@@ -35,10 +34,6 @@ class Admin extends React.Component<State, AdminState> {
   }
 
   render() {
-    if (!this.props.user.db_user.admin) {
-      return (<Redirect to="/" />);
-    }
-
     return (
       <div className="app">
         <header className="header">

--- a/src/components/admin.tsx
+++ b/src/components/admin.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import * as db from '../firebase';
+import { State } from '../providers/GameState';
+import { Redirect } from "react-router-dom";
+import { Map } from './Map';
+import { TileEditor } from './TileEditor';
+
+interface AdminState {
+  selectedRow: number;
+  selectedCol: number;
+  selectedTile: db.TileInfo;
+  tileName: string;
+}
+
+class Admin extends React.Component<State, AdminState> {
+  constructor(props: State) {
+    super(props);
+    this.state = {
+      selectedRow: 0,
+      selectedCol: 0,
+      tileName: this.props.map[0][0],
+      selectedTile: this.props.tiles[this.props.map[0][0]],
+    };
+  }
+
+  onTileClicked(row: number, col: number) {
+    const tileName: string = this.props.map[row][col];
+    const tileData = this.props.tiles[tileName];
+    this.setState({
+      selectedRow: row,
+      selectedCol: col,
+      selectedTile: tileData,
+      tileName: tileName,
+    });
+  }
+
+  render() {
+    if (!this.props.user.db_user.admin) {
+      return (<Redirect to="/" />);
+    }
+
+    return (
+      <div className="app">
+        <header className="header">
+          <h1>Bermuda</h1>
+          <div className="user-info">Bermunda GM - Logged In as: {this.props.user.user.displayName}</div>
+          <button onClick={db.SignOut}> Log Out </button>
+        </header>
+        <div className="content">
+          <Map map={this.props.map}
+            tiles={this.props.tiles}
+            selectedRow={this.state.selectedRow}
+            selectedCol={this.state.selectedCol}
+            onClick={this.onTileClicked.bind(this)} />
+          <div className="sidebar">
+            <div className="turn-info">
+              <p>Turn Number: 1</p>
+              <p>Waiting for GM...</p>
+            </div>
+            <div className="tile-info">
+              <TileEditor tileInfo={this.state.selectedTile} tileName={this.state.tileName}></TileEditor>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Admin;

--- a/src/providers/GameState.tsx
+++ b/src/providers/GameState.tsx
@@ -1,12 +1,6 @@
 import { UserData } from './UserData';
 import { MapRepr, TileDict } from '../firebase';
 
-export interface RouterState {
-  user: null | UserData;
-  map: MapRepr;
-  tiles: TileDict;
-}
-
 export interface State {
   user: UserData;
   map: MapRepr;

--- a/src/providers/GameState.tsx
+++ b/src/providers/GameState.tsx
@@ -1,0 +1,14 @@
+import { UserData } from './UserData';
+import { MapRepr, TileDict } from '../firebase';
+
+export interface RouterState {
+  user: null | UserData;
+  map: MapRepr;
+  tiles: TileDict;
+}
+
+export interface State {
+  user: UserData;
+  map: MapRepr;
+  tiles: TileDict;
+}

--- a/src/providers/UserData.tsx
+++ b/src/providers/UserData.tsx
@@ -3,4 +3,13 @@ export interface UserData {
   game_id: string;
   ship_id: string;
   ship_name: string;
+  db_user: DbUser;
+}
+
+export interface DbUser {
+  admin: boolean;
+}
+
+export function NewDbUser(): DbUser {
+  return {admin: false};
 }

--- a/src/styles/Map.css
+++ b/src/styles/Map.css
@@ -14,6 +14,9 @@
 
 .tile:hover {
   opacity: 90%;
+}
+
+.selected {
   outline-style: solid;
   outline-color: yellow;
 }


### PR DESCRIPTION
Navigation is now split between /admin and /game. Only users with `admin: true` may access the /admin page, and those users will automatically be redirected there upon logging in to the / page.

Admin page right now just allows viewing tile information. Actually editing is TODO.