### PR TITLE
Ben/classified tiles

### DIFF
--- a/src/components/TileEditor.tsx
+++ b/src/components/TileEditor.tsx
@@ -9,6 +9,8 @@ export function TileEditor(props: {
 }) {
   const { register, handleSubmit } = useForm<db.TileInfo>();
   const onSubmit = handleSubmit(async (tileInfo: db.TileInfo) => {
+    // Checkboxes that become checked have the value ['on']. Weird.
+    tileInfo.classified = tileInfo.classified === true || tileInfo.classified as unknown === ['on'];
     db.UpdateTile(props.tileName, tileInfo);
   });
 
@@ -51,6 +53,15 @@ export function TileEditor(props: {
             type="text"
             key={`link:${props.tileInfo.link}`}
             defaultValue={props.tileInfo.link}
+            ref={register} />
+        </label>
+        <br />
+        <label>Classified
+          <input
+            name="classified"
+            type="checkbox"
+            key={`classified:${props.tileInfo.classified}`}
+            defaultChecked={!!props.tileInfo.classified}
             ref={register} />
         </label>
         <br />

--- a/src/components/TilePicker.tsx
+++ b/src/components/TilePicker.tsx
@@ -8,10 +8,15 @@ export function TilePicker(props: {
   tiles: db.TileDict,
   selectedRow: number,
   selectedCol: number,
-  gameId: string
+  gameId: string,
+  showClassified: boolean
 }) {
   const tileList = [...Object.keys(props.tiles)];
-  const tiles = tileList.map( (tileName) =>
+  var reducedList = tileList;
+  if (!props.showClassified) {
+    reducedList = tileList.filter((tileName: string) => !props.tiles[tileName].classified);
+  }
+  const tiles = reducedList.map( (tileName) =>
     <option value={tileName} key={tileName}>{tileName}</option>
   );
   tiles.push(<option value='Create New Tile' key='Create'>Create New Tile</option>);

--- a/src/components/admin.tsx
+++ b/src/components/admin.tsx
@@ -103,7 +103,8 @@ class Admin extends React.Component<AdminProps, AdminState> {
           tiles={this.props.tiles}
           selectedRow={this.state.selectedRow}
           selectedCol={this.state.selectedCol}
-          gameId={this.props.gameId} />
+          gameId={this.props.gameId}
+          showClassified={this.props.user.gm} />
         <TileEditor tileName={tileName}
           tileInfo={tileInfo}
           tiles={this.props.tiles} />

--- a/src/firebase.tsx
+++ b/src/firebase.tsx
@@ -45,6 +45,7 @@ export async function GetDbUser(user: firebase.User): Promise<DbUser> {
     if (userDocData) {
       db_user.admin = (userDocData['admin'] === true);
       db_user.last_game = userDocData['last_game'] as string;
+      db_user.gm = !!userDocData['gm'];
     }
 
     if (db_user.admin && ! db_user.last_game) {
@@ -123,6 +124,7 @@ export interface TileInfo {
   description_text: string;
   hover_text: string;
   link: string;
+  classified: boolean;
 }
 
 // Dictionary for looking up tiles by name.

--- a/src/providers/UserData.tsx
+++ b/src/providers/UserData.tsx
@@ -8,8 +8,9 @@ export interface DbUser {
   admin: boolean;
   last_game: string;
   email: string;
+  gm: boolean;
 }
 
 export function NewDbUser(email: string): DbUser {
-  return {admin: false, last_game: '', email};
+  return {admin: false, last_game: '', email, gm: false};
 }


### PR DESCRIPTION
Allows tiles to be marked as "classified" - these are by default hidden from the selector from admins without the 'gm' flag.