### PR TITLE
Use decimals rather than percentages for css opacity.

### DIFF
--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -21,7 +21,7 @@ export function Tile(props: {tileInfo: TileInfo, selected: boolean, onClick: () 
         props.onClick();
       }}
       style={style}>
-      <div className="hover"> {props.tileInfo.hover_text} </div>
+      <div className="hoverText"> {props.tileInfo.hover_text} </div>
     </td>
   );
 }

--- a/src/styles/Map.css
+++ b/src/styles/Map.css
@@ -12,15 +12,15 @@
 }
 
 .tile:hover {
-  opacity: 90%;
+  opacity: 0.9;
 }
 
-.hover {
+.hoverText {
   visibility: hidden;
   background-color: white;
-  opacity: 100%;
+  opacity: 1.0;
 }
 
-.tile:hover .hover {
+.tile:hover .hoverText {
   visibility: visible;
 }


### PR DESCRIPTION
This is a known bug in the react optimizer:
https://stackoverflow.com/questions/58853844/the-opacity-value-was-changed-to-1-after-building-the-reacjs-project